### PR TITLE
fix: prevent XSS in mermaid codeblocks with htmlEscape

### DIFF
--- a/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,5 +1,4 @@
 <pre class="mermaid">
-    {{- .Inner | safeHTML }}
-  </pre
->
+  {{- .Inner | htmlEscape }}
+</pre>
 {{ .Page.Store.Set "hasMermaid" true }}


### PR DESCRIPTION
Replace safeHTML with htmlEscape to prevent Cross-Site Scripting (XSS) vulnerabilities. Mermaid reads diagram code via textContent, which safely decodes HTML entities, so htmlEscape preserves rendering while blocking malicious tags/scripts. Also fixes a malformed `</pre>` tag.